### PR TITLE
fixing some problems with linux and linking

### DIFF
--- a/endianness_config.h.in
+++ b/endianness_config.h.in
@@ -454,6 +454,6 @@ uint64_t from_big_endian64(uint64_t value) {
 	
 	return endian_data.integer_value;
 }
-#emdif /* ENDIANNESS_CONFIG_FORCE_SYSTEM_IMPLEMENTATION */
+#endif /* ENDIANNESS_CONFIG_FORCE_SYSTEM_IMPLEMENTATION */
 
 #endif /* ENDIANNESS_GENERATED_CONFIG_H_ */

--- a/endianness_config.h.in
+++ b/endianness_config.h.in
@@ -171,7 +171,9 @@
 
 /* 16bit functions */
 #	if defined(ENDIANNESS_CONFIG_HAVE_HTONS_FUNCTIONS)
-#		define htobe16(x) htons(x)
+#       ifndef htobe16
+#		    define htobe16(x) htons(x)
+#       endif
 #		define htole16(x) (x)
 #		define betoh16(x) ntohs(x)
 #		define letoh16(x) (x)
@@ -188,7 +190,9 @@
 #	endif
 /* 32bit functions */
 #	if defined(ENDIANNESS_CONFIG_HAVE_HTONL_FUNCTIONS)
-#		define htobe32(x) htonl(x)
+#       ifndef htobe32
+#		    define htobe32(x) htonl(x)
+#       endif
 #		define htole32(x) (x)
 #			define betoh32(x) ntohl(x)
 #		define letoh32(x) (x)
@@ -205,12 +209,14 @@
 #	endif
 /* 64bit functions */
 #	if defined(ENDIANNESS_CONFIG_HAVE_HTONLL_FUNCTIONS)
-#		define htobe64(x) htonll(x)
+#	    define htobe64(x) htonll(x)
 #		define htole64(x) (x)
 #		define betoh64(x) ntohll(x)
 #		define letoh64(x) (x)
 #	elif defined(ENDIANNESS_CONFIG_HAVE_MSVC_STYLE_BSWAP_FUNCTIONS) || defined(ENDIANNESS_CONFIG_HAVE_GCC_STYLE_BSWAP_FUNCTIONS)
-#		define htobe64(x) __builtin_bswap64(x)
+#       ifndef htobe64
+#		    define htobe64(x) __builtin_bswap64(x)
+#       endif
 #		define htole64(x) (x)
 #		define betoh64(x) __builtin_bswap64(x)
 #		define letoh64(x) (x)

--- a/endianness_config.h.in
+++ b/endianness_config.h.in
@@ -276,6 +276,7 @@
 #	define letoh64(x) from_little_endian64(x)
 #endif
 
+#ifndef ENDIANNESS_CONFIG_FORCE_SYSTEM_IMPLEMENTATION
 /*
 	Datatypes for accessing the bytes of uintNN_t
  */
@@ -453,5 +454,6 @@ uint64_t from_big_endian64(uint64_t value) {
 	
 	return endian_data.integer_value;
 }
+#emdif /* ENDIANNESS_CONFIG_FORCE_SYSTEM_IMPLEMENTATION */
 
 #endif /* ENDIANNESS_GENERATED_CONFIG_H_ */

--- a/endianness_config.h.in
+++ b/endianness_config.h.in
@@ -102,14 +102,14 @@
 #	include <inttypes.h>
 #endif
 
-/* 
-	Using features.h we can test for the GLIBC version. 
+/*
+	Using features.h we can test for the GLIBC version.
 	If it is below 2.9 "endian.h" will be missing the required functions.
 	See http://linux.die.net/man/3/endian
  */
 #ifdef ENDIANNESS_CONFIG_HAVE_FEATURES_H
 #	include <features.h>
-#   if !defined(__GLIBC__) || !defined(__GLIBC_MINOR__) || ((__GLIBC__ < 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ < 9)))
+#	if !defined(__GLIBC__) || !defined(__GLIBC_MINOR__) || ((__GLIBC__ < 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ < 9)))
 #		if defined(ENDIANNESS_CONFIG_HAVE_ENDIAN_H)
 #			undef ENDIANNESS_CONFIG_HAVE_ENDIAN_H
 #		endif
@@ -171,9 +171,9 @@
 
 /* 16bit functions */
 #	if defined(ENDIANNESS_CONFIG_HAVE_HTONS_FUNCTIONS)
-#       ifndef htobe16
-#		    define htobe16(x) htons(x)
-#       endif
+#		ifndef htobe16
+#			define htobe16(x) htons(x)
+#		endif
 #		define htole16(x) (x)
 #		define betoh16(x) ntohs(x)
 #		define letoh16(x) (x)
@@ -190,11 +190,11 @@
 #	endif
 /* 32bit functions */
 #	if defined(ENDIANNESS_CONFIG_HAVE_HTONL_FUNCTIONS)
-#       ifndef htobe32
-#		    define htobe32(x) htonl(x)
-#       endif
+#		ifndef htobe32
+#			define htobe32(x) htonl(x)
+#		endif
 #		define htole32(x) (x)
-#			define betoh32(x) ntohl(x)
+#		define betoh32(x) ntohl(x)
 #		define letoh32(x) (x)
 #	elif defined(ENDIANNESS_CONFIG_HAVE_MSVC_STYLE_BSWAP_FUNCTIONS) || defined(ENDIANNESS_CONFIG_HAVE_GCC_STYLE_BSWAP_FUNCTIONS)
 #		define htobe32(x) __builtin_bswap32(x)
@@ -209,14 +209,14 @@
 #	endif
 /* 64bit functions */
 #	if defined(ENDIANNESS_CONFIG_HAVE_HTONLL_FUNCTIONS)
-#	    define htobe64(x) htonll(x)
+#		define htobe64(x) htonll(x)
 #		define htole64(x) (x)
 #		define betoh64(x) ntohll(x)
 #		define letoh64(x) (x)
 #	elif defined(ENDIANNESS_CONFIG_HAVE_MSVC_STYLE_BSWAP_FUNCTIONS) || defined(ENDIANNESS_CONFIG_HAVE_GCC_STYLE_BSWAP_FUNCTIONS)
-#       ifndef htobe64
-#		    define htobe64(x) __builtin_bswap64(x)
-#       endif
+#		ifndef htobe64
+#			define htobe64(x) __builtin_bswap64(x)
+#		endif
 #		define htole64(x) (x)
 #		define betoh64(x) __builtin_bswap64(x)
 #		define letoh64(x) (x)
@@ -309,29 +309,29 @@ uint16_t to_little_endian16(uint16_t value) {
 	union Endian_Data_16 endian_data;
 	union Endian_Data_16 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[0] = endian_data_copy.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_0_INDEX];
 	endian_data.char_values[1] = endian_data_copy.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_1_INDEX];
-	
+
 	return endian_data.integer_value;
 }
 uint32_t to_little_endian32(uint32_t value) {
 	union Endian_Data_32 endian_data;
 	union Endian_Data_32 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[0] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_0_INDEX];
 	endian_data.char_values[1] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_1_INDEX];
 	endian_data.char_values[2] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_2_INDEX];
 	endian_data.char_values[3] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_3_INDEX];
-	
+
 	return endian_data.integer_value;
 }
 uint64_t to_little_endian64(uint64_t value) {
 	union Endian_Data_64 endian_data;
 	union Endian_Data_64 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[0] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_0_INDEX];
 	endian_data.char_values[1] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_1_INDEX];
 	endian_data.char_values[2] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_2_INDEX];
@@ -340,7 +340,7 @@ uint64_t to_little_endian64(uint64_t value) {
 	endian_data.char_values[5] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_5_INDEX];
 	endian_data.char_values[6] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_6_INDEX];
 	endian_data.char_values[7] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_7_INDEX];
-	
+
 	return endian_data.integer_value;
 }
 
@@ -348,29 +348,29 @@ uint16_t to_big_endian16(uint16_t value) {
 	union Endian_Data_16 endian_data;
 	union Endian_Data_16 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[0] = endian_data_copy.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_1_INDEX];
 	endian_data.char_values[1] = endian_data_copy.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_0_INDEX];
-	
+
 	return endian_data.integer_value;
 }
 uint32_t to_big_endian32(uint32_t value) {
 	union Endian_Data_32 endian_data;
 	union Endian_Data_32 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[0] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_3_INDEX];
 	endian_data.char_values[1] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_2_INDEX];
 	endian_data.char_values[2] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_1_INDEX];
 	endian_data.char_values[3] = endian_data_copy.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_0_INDEX];
-	
+
 	return endian_data.integer_value;
 }
 uint64_t to_big_endian64(uint64_t value) {
 	union Endian_Data_64 endian_data;
 	union Endian_Data_64 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[0] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_7_INDEX];
 	endian_data.char_values[1] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_6_INDEX];
 	endian_data.char_values[2] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_5_INDEX];
@@ -379,7 +379,7 @@ uint64_t to_big_endian64(uint64_t value) {
 	endian_data.char_values[5] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_2_INDEX];
 	endian_data.char_values[6] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_1_INDEX];
 	endian_data.char_values[7] = endian_data_copy.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_0_INDEX];
-	
+
 	return endian_data.integer_value;
 }
 
@@ -387,29 +387,29 @@ uint16_t from_little_endian16(uint16_t value) {
 	union Endian_Data_16 endian_data;
 	union Endian_Data_16 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_0_INDEX] = endian_data_copy.char_values[0];
 	endian_data.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_1_INDEX] = endian_data_copy.char_values[1];
-	
+
 	return endian_data.integer_value;
 }
 uint32_t from_little_endian32(uint32_t value) {
 	union Endian_Data_32 endian_data;
 	union Endian_Data_32 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_0_INDEX] = endian_data_copy.char_values[0];
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_1_INDEX] = endian_data_copy.char_values[1];
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_2_INDEX] = endian_data_copy.char_values[2];
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_3_INDEX] = endian_data_copy.char_values[3];
-	
+
 	return endian_data.integer_value;
 }
 uint64_t from_little_endian64(uint64_t value) {
 	union Endian_Data_64 endian_data;
 	union Endian_Data_64 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_0_INDEX] = endian_data_copy.char_values[0];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_1_INDEX] = endian_data_copy.char_values[1];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_2_INDEX] = endian_data_copy.char_values[2];
@@ -418,7 +418,7 @@ uint64_t from_little_endian64(uint64_t value) {
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_5_INDEX] = endian_data_copy.char_values[5];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_6_INDEX] = endian_data_copy.char_values[6];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_7_INDEX] = endian_data_copy.char_values[7];
-	
+
 	return endian_data.integer_value;
 }
 
@@ -426,29 +426,29 @@ uint16_t from_big_endian16(uint16_t value) {
 	union Endian_Data_16 endian_data;
 	union Endian_Data_16 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_0_INDEX] = endian_data_copy.char_values[1];
 	endian_data.char_values[ENDIANNESS_2_BYTE_TYPE_LSB_PLUS_1_INDEX] = endian_data_copy.char_values[0];
-	
+
 	return endian_data.integer_value;
 }
 uint32_t from_big_endian32(uint32_t value) {
 	union Endian_Data_32 endian_data;
 	union Endian_Data_32 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_0_INDEX] = endian_data_copy.char_values[3];
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_1_INDEX] = endian_data_copy.char_values[2];
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_2_INDEX] = endian_data_copy.char_values[1];
 	endian_data.char_values[ENDIANNESS_4_BYTE_TYPE_LSB_PLUS_3_INDEX] = endian_data_copy.char_values[0];
-	
+
 	return endian_data.integer_value;
 }
 uint64_t from_big_endian64(uint64_t value) {
 	union Endian_Data_64 endian_data;
 	union Endian_Data_64 endian_data_copy;
 	endian_data_copy.integer_value = value;
-	
+
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_0_INDEX] = endian_data_copy.char_values[7];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_1_INDEX] = endian_data_copy.char_values[6];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_2_INDEX] = endian_data_copy.char_values[5];
@@ -457,7 +457,7 @@ uint64_t from_big_endian64(uint64_t value) {
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_5_INDEX] = endian_data_copy.char_values[2];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_6_INDEX] = endian_data_copy.char_values[1];
 	endian_data.char_values[ENDIANNESS_8_BYTE_TYPE_LSB_PLUS_7_INDEX] = endian_data_copy.char_values[0];
-	
+
 	return endian_data.integer_value;
 }
 #endif /* ENDIANNESS_CONFIG_FORCE_SYSTEM_IMPLEMENTATION */


### PR DESCRIPTION
I found the issue that using the (original) method on linux doesn't work well. After including this in multiple files I got warnings about duplicate declarations and linking errors because of multiple declarations. As a workaround I included it in one file and exluded the non-system functions in all others. see https://github.com/zserik/zsdbp5/blob/develop/lib/endian.cxx and https://github.com/zserik/zsdbp5/blob/develop/include/n64.h